### PR TITLE
Make compatible dotfiles directory creation for all platforms

### DIFF
--- a/scripts/dotfiles/create
+++ b/scripts/dotfiles/create
@@ -5,7 +5,7 @@ set -euo pipefail
 source "$DOTLY_PATH/scripts/core/_main.sh"
 
 dotfiles::apply_templating() {
-  sed -i "s|XXX_DOTFILES_PATH_XXX|$DOTFILES_PATH|g" "$DOTFILES_PATH/shell/zsh/.zshenv"
+  perl -i -pe"s|XXX_DOTFILES_PATH_XXX|$DOTFILES_PATH|g" "$DOTFILES_PATH/shell/zsh/.zshenv"
 }
 
 ##? Create the dotfiles structure
@@ -15,7 +15,7 @@ dotfiles::apply_templating() {
 ##?
 
 # @todo Ensure it's not already created
-cp -r "$DOTLY_PATH/dotfiles_template/"* "$DOTFILES_PATH"
+cp -r "$DOTLY_PATH/dotfiles_template/"* "$DOTFILES_PATH/"
 
 dotfiles::apply_templating
 


### PR DESCRIPTION
Apparently `sed` command has different implementations depending on the platform, after a few tests in both Mac and GNU the only way I found to make it work is to actually replace said command.

More information can be found at:
https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux

On the other hand the `cp -r` command wasn't working for me either, looks like the trailing slash is needed (but I don't understand exactly why as it seems Ok without it). 