### PR TITLE
Fix 'invalid mode +111' in find -perm

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -41,6 +41,11 @@ else
   shift 2
   export DOT_TRACE=${TRACE:-false}
 
-  # @todo HERE we have to merge custom and dotly scripts
-  "${DOTLY_PATH}/scripts/${context}/${command}" "$@"
+  if [ -f "${DOTFILES_PATH}/scripts/${context}/${command}" ]; then
+    path_command="${DOTFILES_PATH}/scripts/${context}/${command}"
+  else 
+    path_command="${DOTLY_PATH}/scripts/${context}/${command}"
+  fi
+
+  "${path_command}" "$@"
 fi

--- a/bin/dot
+++ b/bin/dot
@@ -10,7 +10,7 @@ source "$DOTLY_PATH/scripts/core/_main.sh"
 ##?    dot <context> <cmd> [<args>...]
 
 list_command_paths() {
-  find "$DOTFILES_PATH/scripts" -maxdepth 2 -perm +111 -type f |
+  find "$DOTFILES_PATH/scripts" -maxdepth 2 -perm /ugo=x -type f |
     grep -v core |
     sort
 }


### PR DESCRIPTION
1:  **Fix 'invalid mode +111**
`-perm +mode` This is no longer supported in [find](https://man7.org/linux/man-pages/man1/find.1.html)
> I find that using symbolic mode is more expressive for novices like me.  

2: **Fix File or directory does not exist in `DOTLY_PATH`**  
I couldn't run my scripts because I was looking in the dotly folder