### PR TITLE
Fix 'invalid mode' in find -perm

### DIFF
--- a/scripts/core/paths.sh
+++ b/scripts/core/paths.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 paths::list_dotly_scripts() {
-  find "$DOTLY_PATH/scripts" -maxdepth 2 -perm +111 -type f |
+  find "$DOTLY_PATH/scripts" -maxdepth 2 -perm /+111 -type f |
     grep -v core
 }
 
 paths::list_dotfiles_scripts() {
-  find "$DOTFILES_PATH/scripts" -maxdepth 2 -perm +111 -type f |
+  find "$DOTFILES_PATH/scripts" -maxdepth 2 -perm /+111 -type f |
     grep -v core
 }
 


### PR DESCRIPTION
**Fix 'invalid mode' +111**

According to the website of [Finding Files](https://www.man7.org/linux/man-pages/man1/find.1.html)
`-perm +mode` This is no longer supported in **find**  
Should be use `-perm /mode`


`OS: Ubuntu 20`