### PR TITLE
Force to use our 'dot' binary in the installation

### DIFF
--- a/scripts/self/install
+++ b/scripts/self/install
@@ -35,9 +35,7 @@ installer::install_fzf() {
 ##? Usage:
 ##?    install
 
-if ! platform::command_exists dot; then
-  dot() { "$DOTLY_PATH/bin/dot" "$@"; }
-fi
+dot() { "$DOTLY_PATH/bin/dot" "$@"; }
 
 output::answer "Creating dotfiles structure"
 dot dotfiles create 2>&1


### PR DESCRIPTION
Fixes: #5.

You can use the installer from my fork with the updated submodule reference as a temporary workaround till this is merged:

```bash
bash <(curl -s https://raw.githubusercontent.com/mglezsosa/dotly/dot-collision-installation-workaround/installer)
```

Dotly will be installed but you will get plenty of errors when sourcing your new dotfiles because of the collision, so the problem is bigger. Should we give more priority to our dotfiles, dotly and home binaries in the PATH env var by default? 

I've created a branch with this PR's change and setting this priority as well:

https://github.com/mglezsosa/dotly/blob/c595212bc1755c40b48ea08c83e545fe4d420c78/dotfiles_template/shell/_exports/exports.sh#L1

```bash
bash <(curl -s https://raw.githubusercontent.com/mglezsosa/dotly/more-priority-to-dotly-bins/installer)
```