### PR TITLE
Fix: Issue with dot self update

### DIFF
--- a/scripts/self/update
+++ b/scripts/self/update
@@ -10,12 +10,12 @@ source "$DOTLY_PATH/scripts/core/_main.sh"
 ##?    update
 docs::parse "$@"
 
-cd $DOTFILES_PATH
+cd "$DOTFILES_PATH"
 branch=$(git config -f .gitmodules submodule.modules/dotly.branch)
 
 cd "$DOTLY_PATH"
 git discard >/dev/null 2>&1
-git checkout $branch >/dev/null 2>&1
+git checkout "$branch" >/dev/null 2>&1
 git pull >/dev/null 2>&1
 git submodule update --init --recursive > /dev/null 2>&1
 

--- a/scripts/self/update
+++ b/scripts/self/update
@@ -10,9 +10,12 @@ source "$DOTLY_PATH/scripts/core/_main.sh"
 ##?    update
 docs::parse "$@"
 
+cd $DOTFILES_PATH
+branch=$(git config -f .gitmodules submodule.modules/dotly.branch)
+
 cd "$DOTLY_PATH"
 git discard >/dev/null 2>&1
-git checkout master >/dev/null 2>&1
+git checkout $branch >/dev/null 2>&1
 git pull >/dev/null 2>&1
 git submodule update --init --recursive > /dev/null 2>&1
 


### PR DESCRIPTION
Ater executing `dot self update` it ignored the selected branch and change to master in spite of keeping the current branch saved in `.gitmodules`. To apply this fix in your current dotly installation maybe you will need to update dotly module manually because the file must update itself (I am not sure about this affirmation):

```bash
cd "$DOTLY_PATH"
branch=$(git branch --show-current)
git pull --all
git checkout $branch
```

After this you can execute `dot self update` normally.