### PR TITLE
Fix?: priority user scripts folder over dotly scripts folder

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -45,8 +45,8 @@ else
   shift 2
 
   script_path=""
-  script_exist "$DOTFILES_PATH" "$context" "$script" && script_path="$DOTFILES_PATH"
   script_exist "$DOTLY_PATH" "$context" "$script" && script_path="$DOTLY_PATH"
+  script_exist "$DOTFILES_PATH" "$context" "$script" && script_path="$DOTFILES_PATH"
 
   if [ -z "$script_path" ]; then
     output::error "The script <$context / $script> doesn't exist"


### PR DESCRIPTION
With this fix, user custom scripts folder (`$DOTFILES_PATH/scripts`) has priority over dotly scripts folder so you can overwrite dotly commands functions if you want or need.
