### PR TITLE
Feature: Added `dot mac brew cleanup` subcommand to restore mac

### DIFF
--- a/scripts/mac/brew
+++ b/scripts/mac/brew
@@ -2,15 +2,33 @@
 
 source "$DOTLY_PATH/scripts/core/_main.sh"
 
-##? Some brew utils
+##? Some brew utils.
+##?   - If cleanup does not receive any param will take your
+##?     dumped Brewfile from dotly if exist. If does not exists
+##?     and you don't provide a Brewfile will do nothing.
 ##?
 ##? Usage:
 ##?   brew list_installed
+##?   brew cleanup [<optional_path_brewfile>]
 docs::parse "$@"
 
 case $1 in
 "list_installed")
   brew leaves
+  ;;
+"cleanup")
+    HOMEBREW_DUMP_FILE_PATH=${optional_path_brewfile:-"$DOTFILES_PATH/os/mac/brew/Brewfile"}
+    cleanup_cmd="$(which brew) bundle --file=\"${HOMEBREW_DUMP_FILE_PATH}\" --force cleanup"
+    output::write "This will execute the command... "
+    output::write "    $cleanup_cmd"
+    if [[ -f $HOMEBREW_DUMP_FILE_PATH ]]; then
+      output::question "Still want to perform the action?" confirm_action
+      $(which brew) bundle --file="${HOMEBREW_DUMP_FILE_PATH}" --force cleanup
+      output::question "Do you want to execute additional 'brew cleanup'" brew_cleanup
+      [[ ! -z $brew_cleanup ]] && $(which brew) cleanup
+    else
+      output::error "No Brewfile found"
+    fi
   ;;
 *)
   exit 1


### PR DESCRIPTION
Added `dot mac brew cleanup` subcommand to restore mac to the stored Brewfile packages or desired Brewfile provided. Useful because after some time you will probably test many packages for any reason and with these you will perform a full packages uninstall and cleanup.