### PR TITLE
Feature/Fix?: Added install xcode command line tools if you do not have git command…

### DIFF
--- a/installer
+++ b/installer
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 set -euo pipefail
 
 ##? Setups the environment

--- a/installer
+++ b/installer
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-{
 
 set -euo pipefail
 
@@ -83,9 +82,6 @@ if ! command_exists git; then
   else
       case "$OSTYPE" in
         darwin*)
-          #_a "Updating macOS 🌍"
-          #sudo softwareupdate -i -a
-          
           _a "Checking if Command Line Tools are installed 🕵️‍♂️"
           
           xcode-select --install 2>&1 | grep installed > /dev/null
@@ -118,5 +114,3 @@ cd "$DOTLY_PATH"
 
 _a "🎉 dotly installed correctly! 🎉"
 _a "Please, restart your terminal to see the changes"
-
-}

--- a/installer
+++ b/installer
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+{
+
 set -euo pipefail
 
 ##? Setups the environment
@@ -79,8 +81,25 @@ if ! command_exists git; then
     _a "Installing using pacman"
     sudo pacman -S --noconfirm git >/dev/null 2>&1
   else
-    _e "Could not install git, no package provider found"
-    exit 1
+      case "$OSTYPE" in
+        darwin*)
+          #_a "Updating macOS 🌍"
+          #sudo softwareupdate -i -a
+          
+          _a "Checking if Command Line Tools are installed 🕵️‍♂️"
+          
+          xcode-select --install 2>&1 | grep installed > /dev/null
+          if [[ $? ]]; then
+            _a "Installing Command Line Tools 📺"
+            xcode-select --install
+            _q "Press a key after command line tools has finished to continue...👇" "CLT_INSTALLED"
+          fi
+          ;;
+        *)
+          _e "Could not install git, no package provider found"
+          exit 1
+          ;;
+      esac
   fi
 fi
 
@@ -99,3 +118,5 @@ cd "$DOTLY_PATH"
 
 _a "🎉 dotly installed correctly! 🎉"
 _a "Please, restart your terminal to see the changes"
+
+}


### PR DESCRIPTION
Not sure if this is a feature or fix.
Added install xcode command line tools if you do not have git command and under macOS. Previously if you were under macOS without command line extensions and no brew manager the dotly installer finished the install which makes no sense for me because the final target of any dotfiles must be configure your computer to use it with just one command.