### PR TITLE
Platform functions to detect if dotly is running in WSL

### DIFF
--- a/scripts/core/platform.sh
+++ b/scripts/core/platform.sh
@@ -12,7 +12,7 @@ platform::is_linux() {
   [[ $(uname -s) == "Linux" ]]
 }
 
-platform:is_wsl() {
+platform::is_wsl() {
   grep -qEi "(Microsoft|WSL|microsoft)" /proc/version &> /dev/null
 }
 

--- a/scripts/core/platform.sh
+++ b/scripts/core/platform.sh
@@ -11,3 +11,11 @@ platform::is_macos() {
 platform::is_linux() {
   [[ $(uname -s) == "Linux" ]]
 }
+
+platform:is_wsl() {
+  grep -qEi "(Microsoft|WSL|microsoft)" /proc/version &> /dev/null
+}
+
+platform:wsl_home_path(){
+  wslpath "$(wslvar USERPROFILE 2> /dev/null)"
+}

--- a/scripts/core/platform.sh
+++ b/scripts/core/platform.sh
@@ -16,6 +16,6 @@ platform::is_wsl() {
   grep -qEi "(Microsoft|WSL|microsoft)" /proc/version &> /dev/null
 }
 
-platform:wsl_home_path(){
+platform::wsl_home_path(){
   wslpath "$(wslvar USERPROFILE 2> /dev/null)"
 }


### PR DESCRIPTION
## Motivation
I use dotly in my daily work accross 3 different setups: a MacBook Pro, an Ubuntu laptop and a Desktop PC. The easiest way to make dotly work on my PC is using WSL. Creating my custom script I suddenly had the need to create a function to detect if dotly is running on WSL and I thought it could be useful for every dotly user that has faced the same issues.

## How to test

1. Install dotly in WSL
2. Create a script that reads if its WSL and the ask for the path.
3. It should give the home path flawlessly

## Notes
I have a single user system with a single WSL installed. I dont know if this implementation has any kind of trouble with another set of preconditions. 