### PR TITLE
Fix installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           echo "DOTLY_REPOSITORY: $DOTLY_REPOSITORY"
           echo "DOTLY_BRANCH: $DOTLY_BRANCH"
-          echo "DOTLY_ENV: $DOTLY_ENV"
           echo "$HOME/.dotfiles" | bash installer
 
       - name: Debug on error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           echo "DOTLY_REPOSITORY: $DOTLY_REPOSITORY"
           echo "DOTLY_BRANCH: $DOTLY_BRANCH"
+          echo "DOTLY_ENV: $DOTLY_ENV"
           echo "$HOME/.dotfiles" | bash installer
 
       - name: Debug on error

--- a/installer
+++ b/installer
@@ -10,6 +10,7 @@ set -euo pipefail
 DOTLY_REPOSITORY=${DOTLY_REPOSITORY:-CodelyTV/dotly}
 DOTLY_BRANCH=${DOTLY_BRANCH:-master}
 DOTLY_LOG_FILE=${DOTLY_LOG_FILE:-$HOME/dotly.log}
+DOTLY_ENV=${DOTLY_ENV:-PROD}
 export DOTLY_INSTALLER=true
 
 red='\033[0;31m'

--- a/scripts/self/utils/install.sh
+++ b/scripts/self/utils/install.sh
@@ -30,7 +30,7 @@ install_macos_custom() {
   brew list hyperfine || brew install hyperfine | log::file "Installing brew hyperfine"
 
   # More information: https://github.com/CodelyTV/dotly/issues/89
-  # Feel free to remove this if sentence once mas fixes the compatibility issue with Apple Silicon
+  # Feel free to remove this sentence once `mas` fixes the compatibility issue with Apple Silicon
   if ! platform::is_macos_arm; then
     output::answer "Installing mas"
     brew list mas || brew install mas | log::file "Installing mas"

--- a/scripts/self/utils/install.sh
+++ b/scripts/self/utils/install.sh
@@ -29,6 +29,8 @@ install_macos_custom() {
   brew list bat || brew install bat | log::file "Installing brew bat"
   brew list hyperfine || brew install hyperfine | log::file "Installing brew hyperfine"
 
+  # More information: https://github.com/CodelyTV/dotly/issues/89
+  # Feel free to remove this if sentence once mas fixes the compatibility issue with Apple Silicon
   if ! platform::is_macos_arm; then
     output::answer "Installing mas"
     brew list mas || brew install mas | log::file "Installing mas"


### PR DESCRIPTION
Fix ".dotfiles/modules/dotly/scripts/self/utils/install.sh: line 7: DOTLY_ENV: unbound variable" while running the installer outside the CI server

I've set the `DOTLY_ENV` to `PROD` while running the installer as the documentation state understanding that the "production" environment for dotly would be this kind of scenario, but feel free to modify it to something better if you want to 😅