### PR TITLE
Fix: Error in dot Bash autocompletion function

### DIFF
--- a/shell/bash/completions/_dot
+++ b/shell/bash/completions/_dot
@@ -5,11 +5,13 @@ source "$DOTLY_PATH/scripts/core/_main.sh"
 _dot() {
   local suggestions=""
 
-  case ${#COMP_WORDS[@]} in
+  case "${#COMP_WORDS[@]}" in
+  2) suggestions=$(compgen -W "$(dot::list_contexts | tr '\n' ' ')") ;;
   3) suggestions="$(dot::list_context_scripts ${COMP_WORDS[1]})" ;;
-  *) suggestions=$(compgen -W "$(dot::list_contexts | tr '\n' ' ')") ;;
+  *) suggestions=""
   esac
 
+  #suggestions="${#COMP_WORDS[@]}"
   COMPREPLY=($(compgen -W "$suggestions" "${COMP_WORDS[$COMP_CWORD]}"))
 }
 


### PR DESCRIPTION
# Description
Fixed error that after all possible autocompletions that autocompletion can offer, show invalid arguments where were the context (which is the dotly scripts folder again).

# Error
Sample output of the error (wrong output and not error):

```
{◂} ~/.d/s/dotly dot package install
dotfiles  git       package   shell     symlinks
dotly     mac       self      surprise  ui
```

Which arguments are invalid because they're the context (second passed argument).

# Solution

Rewrite of the `case` loop.