### PR TITLE
🍎 Install mas even on Apple Silicon (arm64)

### DIFF
--- a/scripts/self/utils/install.sh
+++ b/scripts/self/utils/install.sh
@@ -29,12 +29,8 @@ install_macos_custom() {
   brew list bat || brew install bat | log::file "Installing brew bat"
   brew list hyperfine || brew install hyperfine | log::file "Installing brew hyperfine"
 
-  # More information: https://github.com/CodelyTV/dotly/issues/89
-  # Feel free to remove this sentence once `mas` fixes the compatibility issue with Apple Silicon
-  if ! platform::is_macos_arm; then
-    output::answer "Installing mas"
-    brew list mas || brew install mas | log::file "Installing mas"
-  fi
+  output::answer "Installing mas"
+  brew list mas || brew install mas | log::file "Installing mas"
 }
 
 install_linux_custom() {


### PR DESCRIPTION
`mas` has added support for Apple Silicon: https://github.com/mas-cli/mas/pull/310

This would unlock being able to better dealing with Xcode issues like: https://github.com/CodelyTV/dotly/issues/89