### PR TITLE
Use Volta instead of NPM to dump global packages in case it is installed

### DIFF
--- a/scripts/package/dump
+++ b/scripts/package/dump
@@ -6,7 +6,7 @@ source "$DOTLY_PATH/scripts/package/utils/dump.sh"
 ##? Dump all installed packages from:
 ##?  * Brew
 ##?  * Python
-##?  * NPM
+##?  * Volta.sh or NPM
 ##?
 ##? Usage:
 ##?   dump
@@ -15,6 +15,11 @@ docs::parse "$@"
 platform::is_macos && package::brew_dump && output::answer "Brew apps dumped on $HOMEBREW_DUMP_FILE_PATH"
 
 platform::command_exists pip3 && package::python_dump && output::answer "Python apps dumped on $PYTHON_DUMP_FILE_PATH"
-platform::command_exists npm && package::npm_dump && output::answer "NPM apps dumped on $NPM_DUMP_FILE_PATH"
+
+if platform::command_exists volta; then
+    package::volta_dump && output::answer "Volta apps dumped on $VOLTA_DUMP_FILE_PATH"
+elif platform::command_exists npm; then
+    package::npm_dump && output::answer "NPM apps dumped on $NPM_DUMP_FILE_PATH"
+fi
 
 output::solution 'All packages dumped'

--- a/scripts/package/import
+++ b/scripts/package/import
@@ -6,7 +6,7 @@ source "$DOTLY_PATH/scripts/package/utils/dump.sh"
 ##? Import previously dumped packages from:
 ##?  * Brew
 ##?  * Python
-##?  * NPM
+##?  * Volta or NPM
 ##?
 ##? Usage:
 ##?   import
@@ -17,6 +17,11 @@ output::write "🎩 Let's import your packages (this could take a while)"
 platform::is_macos && output::header "Importing Brew apps from $HOMEBREW_DUMP_FILE_PATH" && package::brew_import
 
 platform::command_exists pip3 && output::header "Importing Python apps from $PYTHON_DUMP_FILE_PATH" && package::python_import
-platform::command_exists npm && output::header "Importing NPM apps from $NPM_DUMP_FILE_PATH" && package::npm_import
+
+if platform::command_exists volta; then
+    output::header "Importing Volta apps from $VOLTA_DUMP_FILE_PATH" && package::volta_import
+elif platform::command_exists npm; then
+    output::header "Importing NPM apps from $NPM_DUMP_FILE_PATH" && package::npm_import
+fi
 
 output::solution 'All packages imported'

--- a/scripts/package/utils/dump.sh
+++ b/scripts/package/utils/dump.sh
@@ -3,6 +3,7 @@
 HOMEBREW_DUMP_FILE_PATH="$DOTFILES_PATH/os/mac/brew/Brewfile"
 PYTHON_DUMP_FILE_PATH="$DOTFILES_PATH/langs/python/requirements.txt"
 NPM_DUMP_FILE_PATH="$DOTFILES_PATH/langs/js/global_modules.txt"
+VOLTA_DUMP_FILE_PATH="$DOTFILES_PATH/langs/js/volta_dependencies.txt"
 
 package::brew_dump() {
   mkdir -p "$DOTFILES_PATH/os/mac/brew"
@@ -38,5 +39,17 @@ package::npm_dump() {
 package::npm_import() {
   if [ -f "$NPM_DUMP_FILE_PATH" ]; then
     xargs -I_ npm install -g "_" <"$NPM_DUMP_FILE_PATH"
+  fi
+}
+
+package::volta_dump() {
+  mkdir -p "$DOTFILES_PATH/langs/js"
+
+  volta list all --format plain | awk '{print $2}' >"$VOLTA_DUMP_FILE_PATH"
+}
+
+package::volta_import() {
+  if [ -f "$VOLTA_DUMP_FILE_PATH" ]; then
+    xargs -I_ volta install "_" <"$VOLTA_DUMP_FILE_PATH"
   fi
 }


### PR DESCRIPTION
[Volta](https://volta.sh/) is a JavaScript Tool Manager that helps to manage runtimes (node versions), package managers (npm, yarn), and also global modules.

It is similar to [nvm](https://github.com/nvm-sh/nvm) or [n](https://github.com/tj/n) but since it also takes responsibility for managing global modules, it can switch the node binary version under the scenes when you invoke a global module that depends on it. 

#### Example:

You installed [serve](https://github.com/vercel/serve) globally using `node@14.16.0`  then volta will call that specific version of node to run the `serve` command, even if you are using another node version at the moment.

#### Comments on the implementation: 

Users that use Volta, don't use NPM to install global packages, so that's the reason why if the first is present, the latter is not used.