### PR TITLE
Remove -S option that is forced per commit in the dot git commit command

### DIFF
--- a/scripts/git/commit
+++ b/scripts/git/commit
@@ -15,7 +15,7 @@ docs::parse "$@"
 git add -A
 
 if [ -z "$message" ]; then
-  git commit -S
+  git commit
 else
-  git commit -S -m"$1"
+  git commit -m"$1"
 fi


### PR DESCRIPTION
Not sure if you'll agree with this contribution, but I have to try 😬 

IMHO it is generally better to enable the commit gpg signature as a .gitconfig configuration instead of using the `-S` flag on each `git commit`, this is my rationale:

- Users using Dotly may or may not use GPG signature, this way we let them choose (otherwise the `gc` alias don't work unless you configure the key).
- If configured it always works, regardless of how you trigger the commit: `gc`, `git commit`, `dot git commit`, or any other alias.
- Conditional git configs are taken into account, so one can decide to use GPG or not depending on the repo, or parent folder. You can see an example of this in my dotfiles, where I [enable GPG for all my persona repos](https://github.com/d-asensio/dotfiles/blob/86975dfd66140f96c08160240fd0ccde595339be/git/.gitconfig#L12-L15) and [disable it for work-related ones](https://github.com/d-asensio/dotfiles/blob/86975dfd66140f96c08160240fd0ccde595339be/git/lifull/.gitconfig).