### PR TITLE
[🐍 python] Avoid crash in case of not having python dependencies

### DIFF
--- a/scripts/package/update_all
+++ b/scripts/package/update_all
@@ -30,7 +30,7 @@ fi
 
 platform::command_exists tldr && output::header '📜 Updating tldr database' && tldr --update
 platform::command_exists composer && output::header '🐘 Updating Composer' && composer self-update && composer global update
-platform::command_exists pip3 && output::header '🐍 Updating pip' && pip3 freeze --local | grep -v '^\-e' | cut -d = -f 1 | xargs -n1 pip3 install -U
+platform::command_exists pip3 && output::header '🐍 Updating pip' && pip3 freeze --local | grep -v '^\-e' || [[ $? == 1 ]] | cut -d = -f 1 | xargs -n1 pip3 install -U
 platform::command_exists gem && output::header '♦️ Updating gem' && gem update
 platform::command_exists npm && output::header '🌈 Updating npm' && npm install -g npm && npm update -g
 platform::command_exists cargo && output::header '📦 Updating cargo' && cargo install "$(cargo install --list | egrep '^[a-z0-9_-]+ v[0-9.]+:$' | cut -f1 -d' ')"


### PR DESCRIPTION
Having pip3 installed does not imply having defined any dependencies for python.

This change avoids crashing while running the `up` command.

We were crashing because of the combination of `set -euo pipefail` with an empty input for the `grep -v '^\-e'` 🤟