### PR TITLE
[📦 rust] Fix crash while updating cargo dependencies

### DIFF
--- a/scripts/package/update_all
+++ b/scripts/package/update_all
@@ -33,7 +33,7 @@ platform::command_exists composer && output::header '🐘 Updating Composer' && 
 platform::command_exists pip3 && output::header '🐍 Updating pip' && pip3 freeze --local | grep -v '^\-e' | cut -d = -f 1 | xargs -n1 pip3 install -U
 platform::command_exists gem && output::header '♦️ Updating gem' && gem update
 platform::command_exists npm && output::header '🌈 Updating npm' && npm install -g npm && npm update -g
-platform::command_exists cargo && output::header '📦 Updating cargo' && cargo install "$(cargo install --list | egrep '^[a-z0-9_-]+ v[0-9.]+:$' | cut -f1 -d' ')"
+platform::command_exists cargo && output::header '📦 Updating cargo' && cargo install --list | grep -E '^[a-z0-9_-]+ v[0-9.]+:$' | cut -f1 -d' ' | xargs -n1 cargo install
 platform::command_exists deno && output::header '🦕 Updating deno' && deno upgrade
 
 output::empty_line


### PR DESCRIPTION
In case of having multiple Cargo dependencies installed such as:

```sh
{▸} ~ cargo install --list
docpars v0.2.0:
    docpars
git-delta v0.6.0:
    delta
```

The previous command was passing out multiple lines:

```sh
{▸} ~ cargo install --list | grep -E '^[a-z0-9_-]+ v[0-9.]+:$' | cut -f1 -d' '
docpars
git-delta
```

Because of these lines were being received by the very same `cargo install` command, it was failing:

```sh
{▸} ~ cargo install "$(cargo install --list | grep -E '^[a-z0-9_-]+ v[0-9.]+:$' | cut -f1 -d' ')"
    Updating crates.io index
error: could not find `docpars
git-delta` in registry `https://github.com/rust-lang/crates.io-index` with version `*`
```

Now, it executes the `cargo install` multiple times, but at least do not produce crashes 😅

```sh
{▸} ~ cargo install --list | grep -E '^[a-z0-9_-]+ v[0-9.]+:$' | cut -f1 -d' ' | xargs -n1 cargo install
    Updating crates.io index
     Ignored package `docpars v0.2.0` is already installed, use --force to override
    Updating crates.io index
     Ignored package `git-delta v0.6.0` is already installed, use --force to override
```

So we can now successfully execute the `up`/`dot package update_all` command  🎉