### PR TITLE
[Feature] Autoupdater

### DIFF
--- a/bin/dotly
+++ b/bin/dotly
@@ -6,11 +6,56 @@ source "$DOTLY_PATH/scripts/core/_main.sh"
 
 ##? Usage:
 ##?    dotly self-update
+##?    dotly autoupdate
 docs::parse "$@"
+
 
 case $1 in
 "self-update")
   dot self update
+  ;;
+"autoupdate")
+  # Variables with default values
+  DOTLY_AUTO_UPDATE_DAYS=${DOTLY_AUTO_UPDATE_DAYS:-7}
+  DOTLY_AUTO_UPDATE_MODE=${DOTLY_AUTO_UPDATE_MODE:-reminder} # prompt
+  
+  # Other needed variables
+  CURRENT_DIR="$(pwd)"
+
+  # Change to dotly path
+  cd "$DOTLY_PATH"
+
+  if [[ $(date -r "$DOTLY_PATH" +%s) -lt $(date -d "now - $DOTLY_AUTO_UPDATE_DAYS days" +%s) ]] &&\
+    git diff --quiet "origin/$(git branch --show-current)"; then
+
+    output::empty_line
+    output::write " -------------------------------------------"
+    output::write "|  🥳🎉🍾 NEW DOTLY VERSION AVAILABLE 🥳🎉🍾  |"
+    output::write " -------------------------------------------"
+    output::empty_line
+
+    case "$DOTLY_AUTO_UPDATE_MODE" in
+      "auto")
+        output::answer "🚀 Updating"
+        dot self update
+        output::solution "Updated"
+        ;;
+      "prompt")
+        output::yesno "Do you want to update now" &&\
+          output::answer "🚀 Updating" &&\
+          dot self update &&\
+          output::solution "Updated"
+        ;;
+      *)
+        output::write "🚀 To update your current version just type:"
+        output::answer "dotly self-update"
+      ;;
+    esac
+
+    output::empty_line
+  fi
+
+  cd "$CURRENT_DIR"
   ;;
 *)
   exit 1

--- a/dotfiles_template/shell/bash/.bashrc
+++ b/dotfiles_template/shell/bash/.bashrc
@@ -41,3 +41,10 @@ if [ -n "$(ls -A "$DOTFILES_PATH/shell/bash/completions/")" ]; then
     source "$bash_file"
   done
 fi
+
+# Auto Init scripts at the end
+init_scripts_path="$DOTFILES_PATH/shell/init-scripts.enabled/*"
+mkdir -p $init_scripts_path
+for init_script in $init_scripts_path; do
+  source "$init_script"
+done

--- a/dotfiles_template/shell/exports.sh
+++ b/dotfiles_template/shell/exports.sh
@@ -1,3 +1,6 @@
+export DOTLY_AUTO_UPDATE_DAYS=7
+export DOTLY_AUTO_UPDATE_MODE="reminder" # reminder*, auto, prompt
+
 export JAVA_HOME='/Library/Java/JavaVirtualMachines/amazon-corretto-15.jdk/Contents/Home'
 export GEM_HOME="$HOME/.gem"
 export GOPATH="$HOME/.go"

--- a/dotfiles_template/shell/zsh/.zshrc
+++ b/dotfiles_template/shell/zsh/.zshrc
@@ -24,3 +24,10 @@ prompt ${DOTLY_THEME:-codely}
 source "$DOTLY_PATH/shell/zsh/bindings/dot.zsh"
 source "$DOTLY_PATH/shell/zsh/bindings/reverse_search.zsh"
 source "$DOTFILES_PATH/shell/zsh/key-bindings.zsh"
+
+# Auto Init scripts at the end
+init_scripts_path="$DOTFILES_PATH/shell/init-scripts.enabled/*"
+mkdir -p $init_scripts_path
+for init_script in $init_scripts_path; do
+  source "$init_script"
+done

--- a/scripts/core/output.sh
+++ b/scripts/core/output.sh
@@ -20,5 +20,27 @@ output::question() {
     read -rp " $1: " "$2"
   fi
 }
+output::yesno() {
+  local question="$1"
+  local default="${2:-Y}"
+  local PROMPT_REPLY values default_check
+
+  if [[ "$default" =~ ^[Yy] ]]; then
+    values="Y/n"
+    default_check="Yy"
+  else
+    values="y/N"
+    default_check="Nn"
+  fi
+
+  if [ platform::is_macos ]; then
+    echo -n "🤔 $question [$values]: ";
+    read -r "PROMPT_REPLY";
+  else
+    read -rp "🤔 $question [$values]: " "PROMPT_REPLY"
+  fi
+  PROMPT_REPLY=${PROMPT_REPLY:-$default}
+  [[ "$PROMPT_REPLY" =~ ^[$default_check] ]]
+}
 output::empty_line() { echo ''; }
 output::header() { output::empty_line; output::write "${bold_blue}---- $1 ----${normal}"; }

--- a/scripts/self/autoupdater
+++ b/scripts/self/autoupdater
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+source "$DOTLY_PATH/scripts/core/_main.sh"
+
+##? Autoupdater enable/disable script
+##? 
+##?
+##? Usage:
+##?   autoupdater [-h | --help]
+##?   autoupdater [-v | --version]
+##?   autoupdater enable
+##?   autoupdater disable
+##?   autoupdater status
+##?
+##? Options:
+##?   -h --help     Show this help
+##?   -v --version  Show the program version
+##?
+##? Author:
+##?   Gabriel Trabanco Llano <gtrabanco@users.noreply.github.com>
+
+# Options part its important because assign short and long version of the params
+docs::parse "$@"
+
+SCRIPT_NAME="dot self autoupdater"
+SCRIPT_VERSION="1.0.0"
+
+# Print name and version
+if $version; then
+  output::write "$SCRIPT_NAME v$SCRIPT_VERSION"
+  exit
+fi
+
+# Needed vars
+autoupdater_full_path="$DOTLY_PATH/shell/init-scripts/autoupdater_loader"
+init_scripts_dir_path="$DOTFILES_PATH/shell/init-scripts.enabled"
+
+# Create enabled folder if it does not exists
+mkdir -p "$init_scripts_dir_path"
+
+case $1 in
+"enable")
+  [[ -f "$autoupdater_full_path" ]] &&\
+    ln -s "$autoupdater_full_path" "$init_scripts_dir_path/autoupdater_loader"
+  output::solution "DOTLY Autoupdater enabled"
+  ;;
+"disable")
+  rm -f "$init_scripts_dir_path/autoupdater_loader"
+  output::error "DOTLY Autoupdater disabled"
+  ;;
+*)
+  [[ -f "$init_scripts_dir_path/autoupdater_loader" ]] &&\
+    output::solution "DOTLY Autoupdater enabled" ||\
+    output::error "DOTLY Autoupdater disabled"
+  ;;
+esac

--- a/shell/init-scripts/autoupdater_loader
+++ b/shell/init-scripts/autoupdater_loader
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# If auto update is disabled then it should not run
+"$DOTLY_PATH/dotly" autoupdate


### PR DESCRIPTION
This new feature is demanded in #112 

The implementation create a init-scripts folder in dotfiles and you can simply enable/disable autoupdater by executing:
```bash
dot self autoupdater enable
dot self autoupdater disable
dot self autoupdater status
```

Be advised that this feature needs a modification in `.bashrc` and `.zshrc` files so you need to update them manually. Maybe we could add with autoupdater a subcommand to update this files from `$DOTLY_PATH` by simple overwritting.