### PR TITLE
fix: install rust directly from sources

### DIFF
--- a/scripts/self/install
+++ b/scripts/self/install
@@ -25,18 +25,20 @@ installer::install_fzf() {
   fi
 }
 
+installer::install_rust() {
+  output::error "rust not installed, installing"
+
+  curl https://sh.rustup.rs -sSf | sh -s -- -y | log::file "Installing rust from sources"
+
+  export PATH="$HOME/.cargo/bin:$PATH"
+}
+
 if platform::is_macos; then
   output::answer "🍎 Setting up macOS platform"
   install_macos_custom
 fi
 
-! platform::command_exists cargo && output::error "rust not installed, installing" && "$DOTLY_PATH/bin/dot" package install rust | log::file "Installing rust"
-
-if ! platform::command_exists cargo; then
-  output::error "rust not installed, installing"
-  curl https://sh.rustup.rs -sSf | sh -s -- -y | log::file "Installing rust from sources"
-  source "$HOME/.cargo/env"
-fi
+! platform::command_exists cargo && installer::install_rust
 
 ! platform::command_exists docpars && output::error "docpars not installed, installing" && "$DOTLY_PATH/bin/dot" package install docpars | log::file "Installing docpars"
 ! platform::command_exists delta && output::error "delta not installed, installing" && "$DOTLY_PATH/bin/dot" package install git-delta | log::file "Installing git delta"
@@ -68,3 +70,4 @@ zsh "$ZIM_HOME/zimfw.zsh" install | log::file "Installing zim"
 
 output::answer "Installing completions"
 "$DOTLY_PATH/bin/dot" shell zsh reload_completions
+


### PR DESCRIPTION
This PR changes the installation of rust in a way to avoid the package manager and install as recommended in [Rust web](https://www.rust-lang.org/tools/install), which allow us to fix the error (E: Unable to locate package rust) when installing in Ubuntu.

