### PR TITLE
Use {▪} icon for prompt error status

### DIFF
--- a/shell/zsh/themes/prompt_codely_setup
+++ b/shell/zsh/themes/prompt_codely_setup
@@ -19,7 +19,7 @@ prompt_codely_precmd() {
 }
 
 prompt_codely_setup() {
-  local prompt_codely_status='%(?:%F{green}{%F{white}▸%F{green}}:%F{red}{%F{white}▸%F{red}})'
+  local prompt_codely_status='%(?:%F{green}{%F{white}▸%F{green}}:%F{red}{%F{white}▪%F{red}})'
 
   autoload -Uz add-zsh-hook && add-zsh-hook precmd prompt_codely_precmd
 


### PR DESCRIPTION
Use stop icon `{▪}` for the prompt error status.

Red/green status colours may be indistinguishable for people with colour blindness, so this change helps to identify the status.

The icon represents that the command has **stopped** working, which is an analogy of stopping a video.

![image](https://user-images.githubusercontent.com/3189335/116067028-0a642e00-a689-11eb-9b0a-04b518cfec1d.png)
