### PR TITLE
Add Apt dump/import support

### DIFF
--- a/scripts/package/dump
+++ b/scripts/package/dump
@@ -5,6 +5,8 @@ source "$DOTLY_PATH/scripts/package/utils/dump.sh"
 
 ##? Dump all installed packages from:
 ##?  * Brew
+##?  * Apt
+##?  * Snap
 ##?  * Python
 ##?  * Volta.sh or NPM
 ##?

--- a/scripts/package/dump
+++ b/scripts/package/dump
@@ -14,6 +14,8 @@ docs::parse "$@"
 
 platform::is_macos && package::brew_dump && output::answer "Brew apps dumped on $HOMEBREW_DUMP_FILE_PATH"
 
+platform::command_exists apt-mark && package::apt_dump && output::answer "Apt apps dumped on $APT_DUMP_FILE_PATH"
+
 platform::command_exists snap && package::snap_dump && output::answer "Snap apps dumped on $SNAP_DUMP_FILE_PATH"
 
 platform::command_exists pip3 && package::python_dump && output::answer "Python apps dumped on $PYTHON_DUMP_FILE_PATH"

--- a/scripts/package/import
+++ b/scripts/package/import
@@ -16,6 +16,8 @@ output::write "🎩 Let's import your packages (this could take a while)"
 
 platform::is_macos && output::header "Importing Brew apps from $HOMEBREW_DUMP_FILE_PATH" && package::brew_import
 
+platform::command_exists apt-mark && output::header "Importing Apt apps from $APT_DUMP_FILE_PATH" && package::apt_import
+
 platform::command_exists snap && output::header "Importing Snap apps from $SNAP_DUMP_FILE_PATH" && package::snap_import
 
 platform::command_exists pip3 && output::header "Importing Python apps from $PYTHON_DUMP_FILE_PATH" && package::python_import

--- a/scripts/package/utils/dump.sh
+++ b/scripts/package/utils/dump.sh
@@ -1,6 +1,7 @@
 #!/bin/user/env bash
 
 HOMEBREW_DUMP_FILE_PATH="$DOTFILES_PATH/os/mac/brew/Brewfile"
+APT_DUMP_FILE_PATH="$DOTFILES_PATH/os/linux/apt/packages.txt"
 SNAP_DUMP_FILE_PATH="$DOTFILES_PATH/os/linux/snap/packages.txt"
 PYTHON_DUMP_FILE_PATH="$DOTFILES_PATH/langs/python/requirements.txt"
 NPM_DUMP_FILE_PATH="$DOTFILES_PATH/langs/js/global_modules.txt"
@@ -16,6 +17,18 @@ package::brew_dump() {
 package::brew_import() {
   if [ -f "$HOMEBREW_DUMP_FILE_PATH" ]; then
     brew bundle install --file="$HOMEBREW_DUMP_FILE_PATH"
+  fi
+}
+
+package::apt_dump() {
+  mkdir -p "$DOTFILES_PATH/os/linux/apt"
+
+  apt-mark showmanual >"$APT_DUMP_FILE_PATH"
+}
+
+package::apt_import() {
+  if [ -f "$APT_DUMP_FILE_PATH" ]; then
+    xargs sudo apt-get install -y <"$APT_DUMP_FILE_PATH"
   fi
 }
 


### PR DESCRIPTION
Adds `Apt` packages support for `dot package dump` and `dot package import` commands.

The dump process only exports **manually** installed packages.