### PR TITLE
fix bash completions error after installation

### DIFF
--- a/dotfiles_template/shell/bash/.bashrc
+++ b/dotfiles_template/shell/bash/.bashrc
@@ -36,7 +36,7 @@ for bash_file in "$DOTLY_PATH"/shell/bash/completions/*; do
   source "$bash_file"
 done
 
-if [ -n "$(ls -A "$DOTFILES_PATH/shell/bash/completions/")" ]; then
+if [ -n "$(ls "$DOTFILES_PATH/shell/bash/completions/")" ]; then
   for bash_file in "$DOTFILES_PATH"/shell/bash/completions/*; do
     source "$bash_file"
   done


### PR DESCRIPTION
After a clean `dotly` installation, when running `bash`, the following error is shown in the shell:

`bash: /home/dani/.dotfiles/shell/bash/completions/*: No such file or directory`

The root cause of this error is the following: when it searches for bash completions, it takes hidden files (ls -A) into account. Since the `.gitkeep` file exists in the `$DOTFILES_PATH/shell/bash/completions/` directory, it tries to load all completion files from that directory, but since it is empty (it ignores hidden files when traversing all files in the directory) we get the above error.

The change made avoids taking into account hidden files.