### PR TITLE
Feature: User scripts in installation process

### DIFF
--- a/dotfiles_template/self-install-scripts/01-sample-script
+++ b/dotfiles_template/self-install-scripts/01-sample-script
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo "418 - I'm a teapot!"
+echo
+echo "Self install scripts must have chmod u+x to run"
+echo

--- a/dotfiles_template/self-install-scripts/01-sample-script
+++ b/dotfiles_template/self-install-scripts/01-sample-script
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-echo "418 - I'm a teapot!"
+echo "This is a script ran by the restoration process. You can add yours inside '$DOTFILES_PATH/restore_scripts'"
 echo
 echo "Self install scripts must have chmod u+x to run"
 echo

--- a/scripts/self/install
+++ b/scripts/self/install
@@ -75,8 +75,8 @@ zsh "$ZIM_HOME/zimfw.zsh" install | log::file "Installing zim"
 output::answer "Installing completions"
 "$DOTLY_PATH/bin/dot" shell zsh reload_completions
 
-output::answer "Executing self install scripts for custom installings"
-install_scripts_path="$DOTFILES_PATH/self-install-scripts"
+output::answer "Executing custom restore scripts"
+install_scripts_path="$DOTFILES_PATH/restore_scripts"
 if [ -d "$install_scripts_path" ]; then
   find "$install_scripts_path" -mindepth 1 -maxdepth 1 -type l,f -name '*.sh' |\
     sort |\

--- a/scripts/self/install
+++ b/scripts/self/install
@@ -75,3 +75,14 @@ zsh "$ZIM_HOME/zimfw.zsh" install | log::file "Installing zim"
 output::answer "Installing completions"
 "$DOTLY_PATH/bin/dot" shell zsh reload_completions
 
+output::answer "Executing self install scripts for custom installings"
+install_scripts_path="$DOTFILES_PATH/self-install-scripts"
+if [ -d "$install_scripts_path" ]; then
+  find "$install_scripts_path" -mindepth 1 -maxdepth 1 -type l,f -name '*.sh' |\
+    sort |\
+    while read -r install_script; do
+      { [[ -x "$install_script" ]] && . "$install_script" | log::file "Executing afterinstall: $(basename "$install_script")"; } || {
+        output::error "Install script error in $(basename "$install_script")"
+      }
+    done
+fi


### PR DESCRIPTION
# Description
This feature allows any user to store files in their dotfiles that are executed in the installation process and this reduces the stuff that the user needs to do manually after recovering dotfiles.

# Motivation
I had some personal java configuration (and other stuff) to choose the version and some other programs needs to execute some symbolic links after installation this makes me easier how I recover my dotfiles reducing the manual steps I have to do.

Previous to this patch I did that work with annotations in the README.md file and executing all the annotated stuff manually.

To see how I use this feature: https://github.com/gtrabanco/dotfiles/tree/master/self-install-scripts

# How to

1. Create a bash script:
`echo "#!/usr/bin/env bash\necho \"I'm a teapot\"" >| "$DOTFILES_PATH/self-install-scripts/02-sample-script"`
2. Give to it executable permissions or the script won't be executed.
`chmod u+x "$DOTFILES_PATH/self-install-scripts/02-sample-script"`

The scripts are included at the end of `dot self install` using `.` (same result as using `source`). This allow user to have all installation DOTLY variables and DOTLY default functions in the scripts.

The chmod +x is required to allow user for dis/enable scripts.