### PR TITLE
Fix: Added better check if is installed or not a package

### DIFF
--- a/scripts/package/add
+++ b/scripts/package/add
@@ -63,16 +63,16 @@ if [ -z "$skip_recipe" ] && registry::install "$package_name"; then
 
   exit 0
 else
-  package::install $package_manager "$package_name" 2>&1 | log::file "Trying to install $package_name using $package_manager" || true
+  package::command install "$package_name" 2>&1 | log::file "Trying to install $package_name using $package_manager" || true
 
-  if package::is_installed "$package_manager" "$package_name"; then
+  if package::is_installed "$package_name"; then
     output::write "✅ \`$package_name\` installed"
 
     exit 0
   fi
 fi
 
-if ! package::is_installed "$package_manager" "$package_name"; then
+if ! package::is_installed "$package_name"; then
   output::write "❌ \`$package_name\` could not be installed"
 
   exit 1

--- a/scripts/package/add
+++ b/scripts/package/add
@@ -2,6 +2,7 @@
 
 source "$DOTLY_PATH/scripts/core/_main.sh"
 source "$DOTLY_PATH/scripts/package/recipes/_registry.sh"
+source "$DOTLY_PATH/scripts/package/src/package.sh"
 
 ##? Install a package
 ##?

--- a/scripts/package/add
+++ b/scripts/package/add
@@ -12,60 +12,67 @@ if ! ${DOTLY_INSTALLER:-false}; then
   docs::parse "$@"
 fi
 
+if [[ $# -lt 1 ]]; then
+  exit 1
+fi
+
 export PATH="$HOME/.cargo/bin:$PATH"
 
-package::install() {
-  local -r package_manager="$1"
-  local -r package_to_install="$2"
+package::command() {
+  local package_manager
+  local -r command="$1"
+  local -r args=("${@:2}")
 
-  platform::command_exists "$package_manager" || exit 3
+  # Package manager
+  if platform::is_macos; then
+    for package_manager in brew mas ports cargo none; do
+      if platform::command_exists "$package_manager"; then
+        break
+      fi
+    done
+  else
+    for package_manager in apt dnf yum brew pacman cargo none; do
+      if platform::command_exists "$package_manager"; then
+        break
+      fi
+    done
+  fi
+
+  if [[ "$package_manager" == "none" ]]; then
+    return 1
+  fi
 
   local -r file="$DOTLY_PATH/scripts/package/package_managers/$package_manager.sh"
 
-  # unsupported package manager
-  [ ! -f "$file" ] && exit 4
-
-  source "$file"
-
-  local -r install_command="${package_manager}::install"
-
-  "$install_command" "$package_to_install"
+  [[ ! -f "$file" ]] && exit 4
+  . "$file"
+  declare -F "$package_manager::$command" &>/dev/null && "$package_manager::$command" "${args[@]}"
 }
 
-package_name="$1"
-skip_recipe="$2"
+package::is_installed() {
+  package::command is_installed "$1" || platform::command_exists "$1"
+}
 
-platform::command_exists "$package_name" && log::success "$package_name already installed" && exit 0
+package_name="${1:-}"
+skip_recipe="${2:-}"
+
+package::is_installed "$package_manager" "$package_name" && log::success "$package_name already installed" && exit 0
 
 if [ -z "$skip_recipe" ] && registry::install "$package_name"; then
   output::write "✅ \`$package_name\` installed"
 
   exit 0
 else
-  if platform::is_macos; then
-    for package_manager in brew mas ports cargo; do
-      package::install $package_manager "$package_name" 2>&1 | log::file "Trying to install $package_name using $package_manager" || true
+  package::install $package_manager "$package_name" 2>&1 | log::file "Trying to install $package_name using $package_manager" || true
 
-      if platform::command_exists "$package_name"; then
-        output::write "✅ \`$package_name\` installed"
+  if package::is_installed "$package_manager" "$package_name"; then
+    output::write "✅ \`$package_name\` installed"
 
-        exit 0
-      fi
-    done
-  else
-    for package_manager in apt dnf yum brew pacman cargo; do
-      package::install $package_manager "$package_name" 2>&1 | log::file "Trying to install $package_name using $package_manager"
-
-      if platform::command_exists "$package_name"; then
-        output::write "✅ \`$package_name\` installed"
-
-        exit 0
-      fi
-    done
+    exit 0
   fi
 fi
 
-if ! platform::command_exists "$package_name"; then
+if ! package::is_installed "$package_manager" "$package_name"; then
   output::write "❌ \`$package_name\` could not be installed"
 
   exit 1

--- a/scripts/package/package_managers/apt.sh
+++ b/scripts/package/package_managers/apt.sh
@@ -3,3 +3,7 @@
 apt::install() {
   sudo apt-get -y install "$@"
 }
+
+apt::is_installed() {
+  apt list -a "$@" | grep -q 'installed'
+}

--- a/scripts/package/package_managers/brew.sh
+++ b/scripts/package/package_managers/brew.sh
@@ -9,3 +9,7 @@ brew::install() {
 
   brew install "$package"
 }
+
+brew::is_installed() {
+  brew list "$@" &>/dev/null
+}

--- a/scripts/package/package_managers/cargo.sh
+++ b/scripts/package/package_managers/cargo.sh
@@ -3,3 +3,18 @@
 cargo::install() {
   cargo install "$@"
 }
+
+cargo::is_installed() {
+  local package
+  if [[ $# -gt 1 ]]; then
+    for package in "$@"; do
+      if ! cargo install --list | grep -q "$package"; then
+        return 1
+      fi
+    done
+    
+    return 0
+  else
+    [[ -n "${1:-}" ]] && cargo install --list | grep -q "${1:-}"
+  fi
+}

--- a/scripts/package/package_managers/dnf.sh
+++ b/scripts/package/package_managers/dnf.sh
@@ -3,3 +3,18 @@
 dnf::install() {
   sudo dnf -y install "$@"
 }
+
+dnf::is_installed() {
+  local package
+  if [[ $# -gt 1 ]]; then
+    for package in "$@"; do
+      if ! rpm -qa | grep -qw "$package"; then
+        return 1
+      fi
+    done
+    
+    return 0
+  else
+    [[ -n "${1:-}" ]] && rpm -qa | grep -qw "${1:-}"
+  fi
+}

--- a/scripts/package/package_managers/pacman.sh
+++ b/scripts/package/package_managers/pacman.sh
@@ -7,3 +7,7 @@ pacman::install() {
     sudo pacman -S --noconfirm "$@"
   fi
 }
+
+pacman::is_installed() {
+  pacman -Qs "$@" | grep -q 'local'
+}

--- a/scripts/package/package_managers/yum.sh
+++ b/scripts/package/package_managers/yum.sh
@@ -3,3 +3,18 @@
 yum::install() {
   yes | sudo yum install "$@"
 }
+
+yum::is_installed() {
+  local package
+  if [[ $# -gt 1 ]]; then
+    for package in "$@"; do
+      if ! sudo yum list --installed | grep -q "$package"; then
+        return 1
+      fi
+    done
+    
+    return 0
+  else
+    [[ -n "${1:-}" ]] && sudo yum list --installed | grep -q "$2"
+  fi
+}

--- a/scripts/package/src/package.sh
+++ b/scripts/package/src/package.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+package::command() {
+  local package_manager
+  local -r command="$1"
+  local -r args=("${@:2}")
+
+  # Package manager
+  if platform::is_macos; then
+    for package_manager in brew mas ports cargo none; do
+      if platform::command_exists "$package_manager"; then
+        break
+      fi
+    done
+  else
+    for package_manager in apt dnf yum brew pacman cargo none; do
+      if platform::command_exists "$package_manager"; then
+        break
+      fi
+    done
+  fi
+
+  if [[ "$package_manager" == "none" ]]; then
+    return 1
+  fi
+
+  local -r file="$DOTLY_PATH/scripts/package/package_managers/$package_manager.sh"
+
+  [[ ! -f "$file" ]] && exit 4
+  . "$file"
+  declare -F "$package_manager::$command" &>/dev/null && "$package_manager::$command" "${args[@]}"
+}
+
+package::is_installed() {
+  package::command is_installed "$1" || platform::command_exists "$1"
+}


### PR DESCRIPTION
# Description

This PR adds capability to real check if a package is installed or not.

# Motivation

Previous version were handle all packages as binaries but sometimes there are no binaries or the binaries has different name. For example:

```bash
dot package add sponge
```

`sponge` is a command to output content to the same input file in a pipe like:

```bash
cat file | sponge file
```

This binary is not installable with `brew install sponge` it is in `moreutils` package. But `moreutils` is not a binary package so when you tried to install `dot package add moreutils` always return an error even if it is installed.

## Possible issues in this PR

I am not pretty sure about the way of checking if a package is installed in `pacman`, `dnf` and `yum` because I have no way of getting a wrong output (because I do not have those system installed).