### PR TITLE
So that you do not have problems when using different computers with …

### DIFF
--- a/scripts/dotfiles/create
+++ b/scripts/dotfiles/create
@@ -5,10 +5,20 @@ set -euo pipefail
 source "$DOTLY_PATH/scripts/core/_main.sh"
 
 dotfiles::apply_templating() {
+  PRINT_PATH=$(dotfiles::separate_dotpath_if_defalut_path)
   if platform::is_macos; then
-    sed -i '' -e "s|XXX_DOTFILES_PATH_XXX|$DOTFILES_PATH|g" "$DOTFILES_PATH/shell/zsh/.zshenv"
+    sed -i '' -e "s|XXX_DOTFILES_PATH_XXX|$PRINT_PATH|g" "$DOTFILES_PATH/shell/zsh/.zshenv"
   else
-    sed -i -e "s|XXX_DOTFILES_PATH_XXX|$DOTFILES_PATH|g" "$DOTFILES_PATH/shell/zsh/.zshenv"
+    sed -i -e "s|XXX_DOTFILES_PATH_XXX|$PRINT_PATH|g" "$DOTFILES_PATH/shell/zsh/.zshenv"
+  fi
+}
+
+dotfiles::separate_dotpath_if_defalut_path() {
+  if grep -q "^$HOME*" <<< "$DOTFILES_PATH"; then
+    ONLY_DOTPATH=$(echo $DOTFILES_PATH | awk -F"$HOME" '{ print $2 }')
+    echo '$HOME'$ONLY_DOTPATH
+  else
+    echo '$DOTFILES_PATH'
   fi
 }
 


### PR DESCRIPTION
### Description

Use $ HOME variable when defining $ DOTFILES_PATH in .zshenv file when first installing dotly to mitigate errors when you have different usernames on different computers

### Motivation

At work they gave me a mac mini already configured with a username, there I started creating dotfiles and installing dotly, recently I bought a mac for me and installing dotly, when I imported my dotfiles, the username in .zshenv was different for what it launched an error since on my computer I had a username and another at work. I solved it easily by changing in .zshenv the variable /Users/nameuser/.dotfiles for $ HOME / .dotfiles

At the beginning of the error and newbie using dotly scared me a lot XD

It's easy to fix, but I think maybe it would be good if it was added in the .zshenv file when installing if the path is the default one.
