### PR TITLE
Fix "git find" script parameter

### DIFF
--- a/scripts/git/find
+++ b/scripts/git/find
@@ -7,7 +7,7 @@ source "$DOTLY_PATH/scripts/core/_main.sh"
 ##? Find commits by commit message
 ##?
 ##? Usage:
-##?   find "message to find"
+##?   find <message_to_find>
 docs::parse "$@"
 
 git log --pretty=format:'%C(yellow)%h  %Cblue%ad  %Creset%s%Cgreen  [%cn] %Cred%d' --decorate --date=short --regexp-ignore-case --grep=$1


### PR DESCRIPTION
I tried to use this script and I realized that it wasn't working. 

The error was: 
```sh
λ ~/.d/m/dotly on master ✗ dot git find "brew"
Invalid arguments.

Usage:
  find "message to find"
```

After taking a look I saw that the parameter wasn't specified with the right syntax 🕵️ 