### PR TITLE
Updates for Zim 1.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "modules/zimfw"]
-	path = modules/zimfw
-	url = https://github.com/zimfw/zimfw.git
-	ignore = dirty
 [submodule "modules/dotbot"]
 	path = modules/dotbot
 	url = https://github.com/anishathalye/dotbot.git

--- a/dotfiles_template/shell/zsh/.zimrc
+++ b/dotfiles_template/shell/zsh/.zimrc
@@ -2,8 +2,6 @@
 zmodule zimfw/environment
 zmodule zimfw/git-info
 zmodule zimfw/input
-zmodule zsh-users/zsh-autosuggestions
-zmodule zsh-users/zsh-syntax-highlighting
 zmodule zimfw/completion
-
-zhighlighters=(main brackets)
+zmodule zsh-users/zsh-syntax-highlighting
+zmodule zsh-users/zsh-autosuggestions

--- a/dotfiles_template/shell/zsh/.zshenv
+++ b/dotfiles_template/shell/zsh/.zshenv
@@ -1,4 +1,4 @@
 export DOTFILES_PATH="XXX_DOTFILES_PATH_XXX"
 export DOTLY_PATH="$DOTFILES_PATH/modules/dotly"
 export DOTLY_THEME="codely"
-export ZIM_HOME="$DOTFILES_PATH/.zim"
+export ZIM_HOME="$DOTFILES_PATH/shell/zsh/.zim"

--- a/dotfiles_template/shell/zsh/.zshenv
+++ b/dotfiles_template/shell/zsh/.zshenv
@@ -1,4 +1,4 @@
 export DOTFILES_PATH="XXX_DOTFILES_PATH_XXX"
 export DOTLY_PATH="$DOTFILES_PATH/modules/dotly"
 export DOTLY_THEME="codely"
-export ZIM_HOME="$DOTLY_PATH/modules/zimfw"
+export ZIM_HOME="$DOTFILES_PATH/.zim"

--- a/dotfiles_template/shell/zsh/.zshrc
+++ b/dotfiles_template/shell/zsh/.zshrc
@@ -8,7 +8,9 @@ setopt HIST_FCNTL_LOCK
 setopt +o nomatch
 # setopt autopushd
 
-# Start zim
+ZSH_HIGHLIGHT_HIGHLIGHTERS=(main brackets)
+
+# Start Zim
 source "$ZIM_HOME/init.zsh"
 
 # Async mode for autocompletion

--- a/scripts/package/update_all
+++ b/scripts/package/update_all
@@ -31,7 +31,7 @@ platform::command_exists rustup && output::h2 '☢️ Rust compiler' && rustup u
 platform::command_exists deno && output::h2 '🦕 deno' && deno upgrade
 platform::command_exists tldr && output::h2 '📜 tldr database' && tldr --update
 
-output::h2 "Zim Framework" && zsh "$DOTLY_PATH/modules/zimfw/zimfw.zsh" upgrade 2>&1 | log::file "Updating Zim"
+output::h2 "👽 Zim Framework" && zsh "$ZIM_HOME/zimfw.zsh" upgrade 2>&1 | log::file "Upgrading Zim" && zsh "$ZIM_HOME/zimfw.zsh" update 2>&1 | log::file "Updating Zim"
 
 output::empty_line
 output::solution '👌 All your packages have been successfully updated'

--- a/scripts/self/install
+++ b/scripts/self/install
@@ -3,7 +3,7 @@
 source "$DOTLY_PATH/scripts/core/_main.sh"
 source "$DOTLY_PATH/scripts/self/utils/install.sh"
 
-export ZIM_HOME="$DOTFILES_PATH/.zim"
+export ZIM_HOME="$DOTFILES_PATH/shell/zsh/.zim"
 export PATH="$HOME/.cargo/bin:$PATH"
 
 if platform::is_macos; then

--- a/scripts/self/install
+++ b/scripts/self/install
@@ -3,7 +3,7 @@
 source "$DOTLY_PATH/scripts/core/_main.sh"
 source "$DOTLY_PATH/scripts/self/utils/install.sh"
 
-export ZIM_HOME="$DOTLY_PATH/modules/zimfw"
+export ZIM_HOME="$DOTFILES_PATH/.zim"
 export PATH="$HOME/.cargo/bin:$PATH"
 
 if platform::is_macos; then
@@ -32,8 +32,8 @@ if ! str::contains zsh "$SHELL"; then
   sudo chsh -s "$(command -v zsh)" | log::file "Setting zsh as default shell"
 fi
 
-output::answer "Installing zim"
-zsh "$ZIM_HOME/zimfw.zsh" install | log::file "Installing zim"
+output::answer "Installing Zim"
+curl -fsSL --create-dirs -o "$ZIM_HOME/zimfw.zsh" https://github.com/zimfw/zimfw/releases/latest/download/zimfw.zsh 2>&1 | log::file "Downloading zimfw.zsh" && zsh "$ZIM_HOME/zimfw.zsh" install 2>&1 | log::file "Installing Zim"
 
 output::answer "Installing completions"
 "$DOTLY_PATH/bin/dot" shell zsh reload_completions

--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -17,12 +17,7 @@ case $1 in
   sudo sh -c "echo '$asl_conf' > /etc/asl.conf"
   echo "ASL only storing critical files!"
 
-  find "$DOTFILES_PATH/shell/zsh" -name '*.zwc' -exec rm -rf {} \;
-  find "$DOTFILES_PATH/shell/zsh" -name '*.old' -exec rm -rf {} \;
-  find "$DOTLY_PATH/modules/zimfw" -name '*.zwc' -exec rm -rf {} \;
-  find "$DOTLY_PATH/modules/zimfw" -name '*.old' -exec rm -rf {} \;
-
-  /bin/zsh -c "source ${ZDOTDIR:-${HOME}}/.zlogin"
+  zsh "$ZIM_HOME/zimfw.zsh" clean-compiled && zsh "$ZIM_HOME/zimfw.zsh" compile
 
   "$DOTLY_PATH/bin/dot" shell zsh reload_completions
   ;;


### PR DESCRIPTION
Hola! 👋 Qué surpresa tan buena encontrar que a ustedes les gusta Zim y lo utilizan en su dotfiles y su curso de Zsh!

---

See changelog in https://github.com/zimfw/zimfw/blob/master/CHANGELOG.md

Thanks a lot for chosing Zim as the Zsh framework of choice for your dotfiles and your courses!

I spotted a few points where the usage is not compatible with the changes since Zim 1.0.0 (released 2020-01-07):
* The zimfw repo is not intended to be cloned for daily use. You only need the zimfw.zsh file. And downloading it from https://github.com/zimfw/zimfw/releases/latest/download/zimfw.zsh will always give you the latest released version of it.
* .zimrc should only contain module definitions, and it's not sourced anymore when the shell starts.
* `zhighlighters` is deprecated in favor of `ZSH_HIGHLIGHT_HIGHLIGHTERS`, since we're using the zsh-users/zsh-syntax-highlighting module directly now.
* There are two separate zimfw actions: `upgrade` will upgrade the zimfw.zsh file itself, and `update` will update the modules. You usually would want to do both if you want to "up" everything...
