### PR TITLE
[FIX] {▪} ~ mac defaults view_changed failed on clean install 

### DIFF
--- a/scripts/mac/defaults
+++ b/scripts/mac/defaults
@@ -16,6 +16,7 @@ docs::parse "$@"
 
 case $1 in
 "view_changed")
+  script::depends_on git-delta
   current_defaults_path=$(mktemp)
   defaults read >"$current_defaults_path"
 


### PR DESCRIPTION
defaults view_changed on clean install throws error.

----

hey el primer commando que ejecuto y pasa esto... 😁

<img width="576" alt="Screenshot 2022-01-14 at 23 31 28" src="https://user-images.githubusercontent.com/3104968/149595042-4a65208c-e546-4dad-a5e2-3167864d3b39.png">

