### PR TITLE
fix: dump npm global packages

### DIFF
--- a/scripts/package/src/dump.sh
+++ b/scripts/package/src/dump.sh
@@ -68,7 +68,7 @@ package::python_import() {
 package::npm_dump() {
   mkdir -p "$DOTFILES_PATH/langs/js"
 
-  ls -1 /usr/local/lib/node_modules | grep -v npm >"$NPM_DUMP_FILE_PATH"
+  ls -1 $HOMEBREW_PREFIX/lib/node_modules | grep -v npm >"$NPM_DUMP_FILE_PATH"
 }
 
 package::npm_import() {


### PR DESCRIPTION
`dot package dump` shows an error while dumping npm packages due to the change on default homebrew prefix on M1 Macs.

```
 dot package
package dump
 > Brew apps dumped on /Users/roi/.dotfiles/os/mac/brew/Brewfile
 > Python apps dumped on /Users/roi/.dotfiles/langs/python/requirements.txt
ls: /usr/local/lib/node_modules: No such file or directory
```

Changing hardcoded path to use `$HOMEBREW_PREFIX` env var solves the problem