### PR TITLE
Using different paths for M1 or Intel processor

### DIFF
--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -22,14 +22,19 @@ case $1 in
   "$DOTLY_PATH/bin/dot" shell zsh reload_completions
   ;;
 "test_performance")
+  if [[ $(uname -m) == 'arm64' ]]; then
+    ZSH_BIN_PATH='/opt/homebrew/bin/zsh'
+  else
+    ZSH_BIN_PATH='/usr/local/bin/zsh'
+  fi
   script::depends_on hyperfine
 
-  hyperfine '/bin/zsh -i -c exit' '/opt/homebrew/bin/zsh -i -c exit' --warmup 1
+  hyperfine '/bin/zsh -i -c exit' "${ZSH_BIN_PATH} -i -c exit" --warmup 1
 
   echo ""
   echo "ZSH INFO:"
   echo "  🍎 macOS ZSH 📂 /bin/zsh              - $(/bin/zsh --version)"
-  echo "  🍺 Brew ZSH  📂 /opt/homebrew/bin/zsh - $(/opt/homebrew/bin/zsh --version)"
+  echo "  🍺 Brew ZSH  📂 ${ZSH_BIN_PATH} - $(${ZSH_BIN_PATH} --version)"
 
   echo ""
   echo "✨ Currently using $(command -v zsh) ✨"


### PR DESCRIPTION
As you can see in the [Brew.sh](https://docs.brew.sh/Installation) documentation, there are different paths depending on the Mac's processor.

> This script installs Homebrew to its preferred prefix (/usr/local for macOS Intel, /opt/homebrew for Apple Silicon and /home/linuxbrew/.linuxbrew for Linux) so that [you don’t need sudo](https://docs.brew.sh/FAQ#why-does-homebrew-say-sudo-is-bad) when you brew install. It is a careful script; it can be run even if you have stuff installed in the preferred prefix already. It tells you exactly what it will do before it does it too. You have to confirm everything it will do before it starts.