### PR TITLE
feat: add support for 'asdf' sdk manager

### DIFF
--- a/scripts/package/dump
+++ b/scripts/package/dump
@@ -11,6 +11,7 @@ source "$DOTLY_PATH/scripts/package/src/dump.sh"
 ##?  * Python
 ##?  * Volta.sh or NPM
 ##?  * Winget
+##?  * asdf
 ##?
 ##? Usage:
 ##?   dump
@@ -33,5 +34,7 @@ elif platform::command_exists npm; then
 fi
 
 platform::command_exists winget.exe && package::winget_dump && output::answer "Windows apps dumped on $WINGET_DUMP_FILE_PATH"
+
+platform::command_exists asdf && package::asdf_dump && output::answer "asdf SDKs dumped on $ASDF_DUMP_FILE_PATH"
 
 output::write 'All packages dumped'

--- a/scripts/package/import
+++ b/scripts/package/import
@@ -32,4 +32,6 @@ fi
 
 platform::command_exists winget.exe && output::header "Importing Winget apps from $WINGET_DUMP_FILE_PATH" && package::winget_import
 
+platform::command_exists asdf && output::header "Importing Asdf apps from $ASDF_DUMP_FILE_PATH" && package::asdf_import
+
 output::solution 'All packages imported'


### PR DESCRIPTION
**Context**

[asdf](https://asdf-vm.com) is a great SDK manager but dotly has no support to dump/import its managed packages.
 
**Goal**

This PR introduce minimal support for dump/import SDK managed packages by ASDF until later has [native support](https://github.com/asdf-vm/asdf/issues/1298) for dumping/importing SDKs.