### PR TITLE
fix: restore script with -c option leads to infinite loop

### DIFF
--- a/restorer
+++ b/restorer
@@ -45,6 +45,7 @@ EOF
 		;;
 	--continue | -c)
 		continue=true
+		break
 		;;
 	*) ;;
 


### PR DESCRIPTION
There is no exit condition from loop when using _continue_ option in the _restorer_ script