### PR TITLE
feat: avoid updating default macOS Ruby dependencies

### DIFF
--- a/scripts/core/platform.sh
+++ b/scripts/core/platform.sh
@@ -23,8 +23,8 @@ platform::wsl_home_path() {
 }
 
 platform::is_default_macos_ruby() {
-  current_ruby_path=$(command -v ruby)
-  default_ruby_path="/usr/bin/ruby"
+	current_ruby_path=$(command -v ruby)
+	default_ruby_path="/usr/bin/ruby"
 
-  [[ "$current_ruby_path" = "$default_ruby_path" ]]
+	[[ $current_ruby_path == "$default_ruby_path" ]]
 }

--- a/scripts/core/platform.sh
+++ b/scripts/core/platform.sh
@@ -21,3 +21,10 @@ platform::is_wsl() {
 platform::wsl_home_path() {
 	wslpath "$(wslvar USERPROFILE 2>/dev/null)"
 }
+
+platform::is_default_macos_ruby() {
+  current_ruby_path=$(command -v ruby)
+  default_ruby_path="/usr/bin/ruby"
+
+  [[ "$current_ruby_path" = "$default_ruby_path" ]]
+}

--- a/scripts/core/platform.sh
+++ b/scripts/core/platform.sh
@@ -21,10 +21,3 @@ platform::is_wsl() {
 platform::wsl_home_path() {
 	wslpath "$(wslvar USERPROFILE 2>/dev/null)"
 }
-
-platform::is_default_macos_ruby() {
-	current_ruby_path=$(command -v ruby)
-	default_ruby_path="/usr/bin/ruby"
-
-	[[ $current_ruby_path == "$default_ruby_path" ]]
-}

--- a/scripts/package/src/package_managers/gem.sh
+++ b/scripts/package/src/package_managers/gem.sh
@@ -1,3 +1,10 @@
+gem::is_macos_default() {
+	current_ruby_path=$(command -v ruby)
+	default_ruby_path="/usr/bin/ruby"
+
+	platform::is_macos && [[ $current_ruby_path == "$default_ruby_path" ]]
+}
+
 gem::update_all() {
 	outdated=$(gem outdated)
 

--- a/scripts/package/update_all
+++ b/scripts/package/update_all
@@ -24,7 +24,7 @@ platform::command_exists mas && output::h2 '🍎 App Store' && mas::update_all
 platform::command_exists brew && output::h2 '🍺 Brew' && brew::update_all
 platform::command_exists pip3 && output::h2 '🐍 pip' && pip::update_all
 platform::command_exists composer && output::h2 '🐘 Composer' && composer::update_all
-platform::command_exists gem && ! platform::is_default_macos_ruby && output::h2 '♦️  gem' && gem::update_all
+platform::command_exists gem && ! gem::is_macos_default && output::h2 '♦️  gem' && gem::update_all
 platform::command_exists npm && output::h2 '🌈 npm' && npm::update_all
 platform::command_exists cargo && output::h2 '📦 cargo' && cargo::update_all
 

--- a/scripts/package/update_all
+++ b/scripts/package/update_all
@@ -24,7 +24,7 @@ platform::command_exists mas && output::h2 '🍎 App Store' && mas::update_all
 platform::command_exists brew && output::h2 '🍺 Brew' && brew::update_all
 platform::command_exists pip3 && output::h2 '🐍 pip' && pip::update_all
 platform::command_exists composer && output::h2 '🐘 Composer' && composer::update_all
-platform::command_exists gem && output::h2 '♦️  gem' && gem::update_all
+platform::command_exists gem && ! platform::is_default_macos_ruby && output::h2 '♦️  gem' && gem::update_all
 platform::command_exists npm && output::h2 '🌈 npm' && npm::update_all
 platform::command_exists cargo && output::h2 '📦 cargo' && cargo::update_all
 


### PR DESCRIPTION
Why:
- Right now dotly tries to update all the Ruby dependencies from the Ruby installation that comes with macOS by default, but it fails in a lot of cases due to errors because the newer dependencies versions require an updated version of Ruby. Example:
  >ERROR:  Error installing irb:
	There are no versions of irb (= 1.7.4) compatible with your Ruby & RubyGems
	irb requires Ruby version >= 2.7. The current ruby version is 2.6.10.210.
- Because these errors, dotly is not able to update these dependencies so it will indefinitely try to do so on each `up` command execution. This permanently increases the command execution time and adds noise to the command output.
- It is not recommended to update the default Ruby installation that comes with macOS because the [2.6 version is included for compatibility with legacy software](https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes#3318257:~:text=Use%20of%20Python%202.7%20isn%E2%80%99t%20recommended%20as%20this%20version%20is%20included%20in%20macOS%20for%20compatibility%20with%20legacy%20software).
- Based on the previous point, updating the default dependencies that comes with that version of Ruby does not seems like a good option because it could break that legacy software compatibility, however, if we would want to go that route we would face other problems:
  - Requiring dotly users to install rbenv, ruby with brew, or something similar in order to replace the default Ruby installation with a newer one just because being able to update the dependencies seems to be adding unnecessary steps to the dotly installation, specially when these users may not even use Ruby
  - Adding an updated version of Ruby with dotly seems to be adding unnecessary dependencies to the default dotly installation
- [macOS is planning to remove that default Ruby installation](https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes#Scripting-Language-Runtimes:~:text=Future%20versions%20of%20macOS%20won%E2%80%99t%20include%20scripting%20language%20runtimes%20by%20default)

Conclusion: We would opt for avoiding to update the default Ruby installation. If you do not develop with Ruby but just have it because it comes by default with the macOS installation, you probably do not bother to maintain these dependencies updated. Even if it bothers you, updating these dependencies could break some legacy compatibility which is the primary reason why they are there.