### PR TITLE
fix: use pip3 instead of pip

### DIFF
--- a/scripts/package/src/package_managers/pip.sh
+++ b/scripts/package/src/package_managers/pip.sh
@@ -17,7 +17,7 @@ pip::update_all() {
 			output::write "└ $url"
 			output::empty_line
 
-			pip install -U "$package" 2>&1 | log::file "Updating pip app: $package"
+			pip3 install -U "$package" 2>&1 | log::file "Updating pip app: $package"
 		done
 	else
 		output::answer "Already up-to-date"


### PR DESCRIPTION
- We are actually checking if `platform::command_exists pip3` (not `platform::command_exists pip` before executing `pip::update_all`
- Inside the `pip::update_all` function we are already interacting with `pip3` in order to list outdated dependencies and show information about them
- It does not feel consistent to use `pip` while actually updating these dependencies
- It even throws an error every time we execute the `up` dotly command if we have not installed a Python environment further more the one which comes with macOS by default